### PR TITLE
issue #12 OAuth2でUserの特定ができるようにする（PR3）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - LODQA=http://lodqa:9292
       - LODQA_BS=http://lodqa_bs:3000
       - URL_FORWARDING_DB=http://uri-forwarding-db:3000
+      - LODQA_OAUTH=http://lodqa:9292
       - CLIENT_ID=1090809463773-aphb48v6bg0tnhq2cgr301qvm90rtae4.apps.googleusercontent.com
       - CLIENT_SECRET=_lWA_yX1WqE1iOw5e0GU8oWO
     depends_on:

--- a/lib/lodqa/bs_client.rb
+++ b/lib/lodqa/bs_client.rb
@@ -25,7 +25,7 @@ module Lodqa
         end
       end
 
-      def register_pgp_and_mappings ws, request_id, pgp, mappings, read_timeout, sparql_limit, answer_limit, target
+      def register_pgp_and_mappings ws, request_id, pgp, mappings, read_timeout, sparql_limit, answer_limit, target, user_id
         send_bs_error_on ws do
           url = "#{ENV['LODQA_BS']}/searches"
           payload = {
@@ -35,6 +35,7 @@ module Lodqa
             sparql_limit: sparql_limit,
             answer_limit: answer_limit,
             target: target,
+            user_id: user_id,
             callback_url: "#{ENV['LODQA']}/requests/#{request_id}/black_hall"
           }.delete_if { |k, v| v.nil? || v.empty? }
           RestClient::Request.execute method: :post, url: url, payload: payload

--- a/lib/lodqa/oauth.rb
+++ b/lib/lodqa/oauth.rb
@@ -4,9 +4,9 @@ require 'json'
 
 module Lodqa
   class Oauth
-    LOGIN = "#{ENV['LODQA']}/login"
-    LOGOUT = "#{ENV['LODQA']}/logout"
-    REDIRECT_URI="#{ENV['LODQA']}/oauth"
+    LOGIN = "#{ENV['LODQA_OAUTH']}/login"
+    LOGOUT = "#{ENV['LODQA_OAUTH']}/logout"
+    REDIRECT_URI="#{ENV['LODQA_OAUTH']}/oauth"
     URL_TOKEN_INFO = 'https://oauth2.googleapis.com/tokeninfo'
     URL_TOKEN = 'https://accounts.google.com/o/oauth2/token'
     URL_REVOKE= 'https://accounts.google.com/o/oauth2/revoke'

--- a/lodqa-ws.rb
+++ b/lodqa-ws.rb
@@ -267,7 +267,7 @@ class LodqaWS < Sinatra::Base
 				mappings = json[:mappings]
 
 				start_and_sparql_count ws, params[:target], params[:read_timeout], params[:sparql_limit], params[:answer_limit], pgp, mappings, request_id
-				register_pgp_and_mappings ws, params[:target], params[:read_timeout], params[:sparql_limit], params[:answer_limit], pgp, mappings, request_id, session[:email] || nil
+				register_pgp_and_mappings ws, params[:target], params[:read_timeout], params[:sparql_limit], params[:answer_limit], pgp, mappings, request_id, session[:email]
 			end
 
 			ws.rack_response

--- a/lodqa-ws.rb
+++ b/lodqa-ws.rb
@@ -267,7 +267,7 @@ class LodqaWS < Sinatra::Base
 				mappings = json[:mappings]
 
 				start_and_sparql_count ws, params[:target], params[:read_timeout], params[:sparql_limit], params[:answer_limit], pgp, mappings, request_id
-				register_pgp_and_mappings ws, params[:target], params[:read_timeout], params[:sparql_limit], params[:answer_limit], pgp, mappings, request_id
+				register_pgp_and_mappings ws, params[:target], params[:read_timeout], params[:sparql_limit], params[:answer_limit], pgp, mappings, request_id, session[:email] || nil
 			end
 
 			ws.rack_response
@@ -329,8 +329,8 @@ class LodqaWS < Sinatra::Base
 		end
 	end
 
-	def register_pgp_and_mappings ws, target, read_timeout, sparql_limit, answer_limit, pgp, mappings, request_id
-		res = Lodqa::BSClient.register_pgp_and_mappings ws, request_id, pgp, mappings, read_timeout, sparql_limit, answer_limit, target
+	def register_pgp_and_mappings ws, target, read_timeout, sparql_limit, answer_limit, pgp, mappings, request_id, user_id
+		res = Lodqa::BSClient.register_pgp_and_mappings ws, request_id, pgp, mappings, read_timeout, sparql_limit, answer_limit, target, user_id
 
 		data = JSON.parse res
 		subscribe_url = data['subscribe_url']

--- a/views/grapheditor.erb
+++ b/views/grapheditor.erb
@@ -30,6 +30,11 @@
         <li><a href="<%= settings.target_db %>">Targets</a></li>
         <li><a href="http://www.lodqa.org/docs/intro/">Doc</a></li>
         <li><a href="https://github.com/lodqa/lodqa">Github</a></li>
+        <% if session[:email] == nil %>
+          <li><a href="<%= Lodqa::Oauth::LOGIN %>">Login</a></li>
+        <% else %>
+          <li><a href="<%= Lodqa::Oauth::LOGOUT %>">Logout</a></li>
+        <% end %>
       </ul>
     </nav>
     <div id="target-box">


### PR DESCRIPTION
Expertモード時に
　リンク表示（Login・Logoutのリンク切り替え）
　Login済・検索された場合はLoginされたメールアドレスをパラメータ（user_id）としてbsへ送る。

　

